### PR TITLE
feature: Mypage UI profile

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,12 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        hostname: 'jtorewqfshytdtgldztv.supabase.co'
+      }
+    ]
+  }
+};
 
 export default nextConfig;

--- a/src/app/(home)/(profile)/_components/MyActivities.tsx
+++ b/src/app/(home)/(profile)/_components/MyActivities.tsx
@@ -7,6 +7,7 @@ import LikesList from './myactivities/LikesList';
 import BookmarksList from './myactivities/BookmarksList';
 import MyActivitiesHeader from './myactivities/MyActivitiesHeader';
 
+//임시
 type PostType = 'all' | 'QnA' | 'archiving' | 'forum';
 
 const MyActivities = () => {

--- a/src/app/(home)/(profile)/_components/MyActivities.tsx
+++ b/src/app/(home)/(profile)/_components/MyActivities.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React, { useState } from 'react';
+import useActiveTabStore from '@/store/useActiveTabStore';
+import MyPostsList from './myactivities/MyPostsList';
+import LikesList from './myactivities/LikesList';
+import BookmarksList from './myactivities/BookmarksList';
+import MyActivitiesHeader from './myactivities/MyActivitiesHeader';
+
+type PostType = 'all' | 'QnA' | 'archiving' | 'forum';
+
+const MyActivities = () => {
+  const activeTab = useActiveTabStore((state) => state.activeTab);
+  const setActiveTab = useActiveTabStore((state) => state.setActiveTab);
+  const [filter, setFilter] = useState<PostType>('all');
+
+  const handleFilterChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setFilter(event.target.value as PostType);
+  };
+
+  const renderActiveTab = () => {
+    switch (activeTab) {
+      case 'posts':
+        return <MyPostsList filter={filter} />;
+      case 'likes':
+        return <LikesList filter={filter} />;
+      case 'bookmarks':
+        return <BookmarksList filter={filter} />;
+    }
+  };
+
+  return (
+    <div>
+      <MyActivitiesHeader setActiveTab={setActiveTab} activeTab={activeTab} />
+      {activeTab && (
+        <div>
+          <select id="filter" value={filter} onChange={handleFilterChange} className="p-2 border rounded">
+            <option value="all">전체</option>
+            <option value="QnA">QnA</option>
+            <option value="archiving">아카이빙</option>
+            <option value="forum">포럼</option>
+          </select>
+          {renderActiveTab()}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MyActivities;

--- a/src/app/(home)/(profile)/_components/ProfileContent.tsx
+++ b/src/app/(home)/(profile)/_components/ProfileContent.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import useActiveTabStore from '@/store/useActiveTabStore';
+import Image from 'next/image';
+import Link from 'next/link'; // next/link 임포트
+import { useState } from 'react';
+
+// 임시 User 타입
+type User = {
+  id: string;
+  profile_image: string;
+  email: string;
+  nickname: string;
+  github_url?: string;
+  info: string;
+  like: string;
+  bookmark: string;
+};
+
+const ProfileContent = () => {
+  const setActiveTab = useActiveTabStore((state) => state.setActiveTab);
+
+  const [user, setUser] = useState<User>({
+    id: '618962ac-e431-4ccd-9ca1-dc916435f8da',
+    profile_image:
+      'https://jtorewqfshytdtgldztv.supabase.co/storage/v1/object/sign/profile_image/18_20240511012529.png?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJwcm9maWxlX2ltYWdlX2ltYWdlLzE4XzIwMjQwNTExMDEyNTI5LnBuZyIsImlhdCI6MTcyMTYyNTQ3NiwiZXhwIjoyMDM2OTg1NDc2fQ.nKa_eNvxhs2qasseDYM8pO6mUZKPfrbnQr0TPBiSUPs',
+    email: 'admin@admin.com',
+    nickname: 'admin',
+    github_url: '',
+    info: 'Short info about the user.',
+    like: '10',
+    bookmark: '30'
+  });
+
+  const handleLikeClick = () => {
+    setActiveTab('likes');
+  };
+
+  const handleBookmarkClick = () => {
+    setActiveTab('bookmarks');
+  };
+
+  return (
+    <div className="w-[740px] h-[566px] p-4 border rounded-lg shadow-lg">
+      <div className="flex flex-col justify-center items-center mb-4">
+        <Image
+          src={user.profile_image}
+          alt="프로필 이미지"
+          width={80}
+          height={80}
+          className="rounded-full bg-red-300"
+        />
+        <div>
+          <p className="text-lg font-semibold">{user.nickname}</p>
+        </div>
+      </div>
+      <div className="flex justify-between">
+        <div>
+          <p className="">깃허브 링크</p>
+          <p className="">자기소개</p>
+        </div>
+        <div>
+          {user.github_url ? (
+            <a href={user.github_url} className="text-blue-500">
+              연결됨
+            </a>
+          ) : (
+            <p className="text-gray-500">비연동</p>
+          )}
+          <p className="text-gray-600">{user.info}</p>
+        </div>
+      </div>
+      <div className="flex justify-around mt-8">
+        <Link href="/profile/activities">
+          <div className="text-center cursor-pointer" onClick={handleLikeClick}>
+            <p className="text-gray-600">좋아요</p>
+            <p>{user.like}</p>
+          </div>
+        </Link>
+        <Link href="/profile/activities">
+          <div className="text-center cursor-pointer" onClick={handleBookmarkClick}>
+            <p className="text-gray-600">북마크</p>
+            <p>{user.bookmark}</p>
+          </div>
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileContent;

--- a/src/app/(home)/(profile)/_components/ProfileContent.tsx
+++ b/src/app/(home)/(profile)/_components/ProfileContent.tsx
@@ -2,7 +2,7 @@
 
 import useActiveTabStore from '@/store/useActiveTabStore';
 import Image from 'next/image';
-import Link from 'next/link'; // next/link 임포트
+import Link from 'next/link';
 import { useState } from 'react';
 
 // 임시 User 타입
@@ -54,18 +54,18 @@ const ProfileContent = () => {
           <p className="text-lg font-semibold">{user.nickname}</p>
         </div>
       </div>
-      <div className="flex justify-between">
+      <div className="flex justify-between p-10">
         <div>
-          <p className="">깃허브 링크</p>
+          <p className="my-6">깃허브 링크</p>
           <p className="">자기소개</p>
         </div>
-        <div>
+        <div className="mr-[180px]">
           {user.github_url ? (
-            <a href={user.github_url} className="text-blue-500">
+            <a href={user.github_url} className="text-blue-500 my-6">
               연결됨
             </a>
           ) : (
-            <p className="text-gray-500">비연동</p>
+            <p className="text-gray-500 my-6">비연동</p>
           )}
           <p className="text-gray-600">{user.info}</p>
         </div>

--- a/src/app/(home)/(profile)/_components/ProfileSetting.tsx
+++ b/src/app/(home)/(profile)/_components/ProfileSetting.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import Image from 'next/image';
+import EditableField from './setting/EditableField';
+
+// 임시 User 타입
+type User = {
+  id: string;
+  profile_image: string;
+  email: string;
+  nickname: string;
+  github_url: string;
+  info: string;
+  like: string;
+  bookmark: string;
+};
+
+const ProfileSetting = () => {
+  const [user, setUser] = useState<User>({
+    id: '618962ac-e431-4ccd-9ca1-dc916435f8da',
+    profile_image:
+      'https://jtorewqfshytdtgldztv.supabase.co/storage/v1/object/sign/profile_image/18_20240511012529.png?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJwcm9maWxlX2ltYWdlLzE4XzIwMjQwNTExMDEyNTI5LnBuZyIsImlhdCI6MTcyMTYyNTQ3NiwiZXhwIjoyMDM2OTg1NDc2fQ.nKa_eNvxhs2qasseDYM8pO6mUZKPfrbnQr0TPBiSUPs',
+    email: 'admin@admin.com',
+    nickname: 'admin',
+    github_url: 'https://github.com/',
+    info: 'Short info about the user.',
+    like: '10',
+    bookmark: '30'
+  });
+
+  const [showInput, setShowInput] = useState<null | string>(null);
+  const userDefaultImage =
+    'https://jtorewqfshytdtgldztv.supabase.co/storage/v1/object/public/profile_image/free-icon-user-747376.png?t=2024-07-22T05%3A29%3A24.993Z';
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {};
+
+  const handleLabelClick = (field: string) => {
+    setShowInput((prevField) => (prevField === field ? null : field));
+  };
+
+  // 프로필 이미지 파일 변경 핸들러
+  const handleProfileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files) {
+      const file = event.target.files[0];
+    }
+  };
+
+  // 프로필 이미지 클릭 핸들러
+  const handleImageClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  return (
+    <div className="w-full max-w-md mx-auto p-4">
+      <p>계정 관리</p>
+      <p>서비스에서 사용하는 내 계정 정보를 관리할 수 있습니다.</p>
+      <div onClick={handleImageClick}>
+        <Image src={user.profile_image || userDefaultImage} alt="Profile" width={200} height={200} priority />
+        <input type="file" accept="image/*" onChange={handleProfileChange} ref={fileInputRef} />
+      </div>
+      <div className="flex items-center mb-4">
+        <span className="mr-[90px]">이메일</span>
+        <span>{user.email}</span>
+      </div>
+      <EditableField
+        label="닉네임"
+        name="nickname"
+        value={user.nickname}
+        showInput={showInput}
+        onChange={handleChange}
+        onLabelClick={handleLabelClick}
+      />
+      <EditableField
+        label="깃허브 링크"
+        name="github_url"
+        value={user.github_url}
+        showInput={showInput}
+        onChange={handleChange}
+        onLabelClick={handleLabelClick}
+      />
+      <EditableField
+        label="자기소개"
+        name="info"
+        value={user.info}
+        showInput={showInput}
+        onChange={handleChange}
+        onLabelClick={handleLabelClick}
+      />
+      //임시
+      <button>회원탈퇴</button>
+    </div>
+  );
+};
+
+export default ProfileSetting;

--- a/src/app/(home)/(profile)/_components/ProfileSidebar.tsx
+++ b/src/app/(home)/(profile)/_components/ProfileSidebar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import React from 'react';
 
-const ProfileSidebar: React.FC = () => {
+const ProfileSidebar = () => {
   const pathname = usePathname();
 
   return (

--- a/src/app/(home)/(profile)/_components/ProfileSidebar.tsx
+++ b/src/app/(home)/(profile)/_components/ProfileSidebar.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import React from 'react';
+
+const ProfileSidebar: React.FC = () => {
+  const pathname = usePathname();
+
+  return (
+    <nav className="w-[286px] h-screen bg-[#eeeeee] p-8 overflow-y-hidden">
+      <ul>
+        <li className="my-14">
+          <Link href="/profile" className={pathname === '/profile' ? 'text-black' : 'text-gray-500'}>
+            프로필
+          </Link>
+        </li>
+        <li className="my-14">
+          <Link
+            href="/profile/activities"
+            className={pathname === '/profile/activities' ? 'text-black' : 'text-gray-500'}
+          >
+            내 활동
+          </Link>
+        </li>
+        <li className="my-14">
+          <Link href="/profile/settings" className={pathname === '/profile/settings' ? 'text-black' : 'text-gray-500'}>
+            설정
+          </Link>
+        </li>
+        <li>
+          <button className="text-gray-500">로그아웃</button>
+        </li>
+      </ul>
+    </nav>
+  );
+};
+
+export default ProfileSidebar;

--- a/src/app/(home)/(profile)/_components/myactivities/BookmarksList.tsx
+++ b/src/app/(home)/(profile)/_components/myactivities/BookmarksList.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const BookmarksList = (filter: any) => {
+  return <div>BookmarksList</div>;
+};
+
+export default BookmarksList;

--- a/src/app/(home)/(profile)/_components/myactivities/CommentCard.tsx
+++ b/src/app/(home)/(profile)/_components/myactivities/CommentCard.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface CommentCardProps {
+  content: string;
+  profilePicture: string;
+  image: string;
+  time: Date;
+}
+
+const CommentCard: React.FC<CommentCardProps> = ({ content, profilePicture, image, time }) => {
+  return (
+    <div>
+      <p>{content}</p>
+      <p>
+        <img src={profilePicture} alt="Profile" />
+      </p>
+      <p>
+        <img src={image} alt="Comment Image" />
+      </p>
+      <p>{time.toLocaleString()}</p>
+    </div>
+  );
+};
+
+export default CommentCard;

--- a/src/app/(home)/(profile)/_components/myactivities/CommentCard.tsx
+++ b/src/app/(home)/(profile)/_components/myactivities/CommentCard.tsx
@@ -1,21 +1,23 @@
 import React from 'react';
 
-interface CommentCardProps {
-  content: string;
-  profilePicture: string;
-  image: string;
+type CommentCardProps = {
+  title: string;
+  comment: string;
+  userNickname: string;
+  userImage: string;
   time: Date;
-}
+};
 
-const CommentCard: React.FC<CommentCardProps> = ({ content, profilePicture, image, time }) => {
+const CommentCard = ({ title, comment, userNickname, userImage, time }: CommentCardProps) => {
   return (
     <div>
-      <p>{content}</p>
+      <p>{title}</p>
+      <p>{comment}</p>
       <p>
-        <img src={profilePicture} alt="Profile" />
-      </p>
+        <img src={userImage} alt="user Image" />
+      </p>{' '}
       <p>
-        <img src={image} alt="Comment Image" />
+        <img src={userNickname} alt="user Nickname" />
       </p>
       <p>{time.toLocaleString()}</p>
     </div>

--- a/src/app/(home)/(profile)/_components/myactivities/LikesList.tsx
+++ b/src/app/(home)/(profile)/_components/myactivities/LikesList.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const LikesList = (filter: any) => {
+  return <div>LikesList</div>;
+};
+
+export default LikesList;

--- a/src/app/(home)/(profile)/_components/myactivities/MyActivitiesHeader.tsx
+++ b/src/app/(home)/(profile)/_components/myactivities/MyActivitiesHeader.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+type MyActivitiesHeaderProps = {
+  setActiveTab: (tab: string) => void;
+  activeTab: string;
+};
+
+const MyActivitiesHeader: React.FC<MyActivitiesHeaderProps> = ({ setActiveTab, activeTab }) => {
+  return (
+    <header>
+      <nav className="w-full bg-[#E3E3E3] p-5 overflow-y-hidden">
+        <ul className="flex justify-between mx-[50px]">
+          <li
+            className={`${activeTab === 'posts' ? 'text-black  ' : 'text-gray-500'}`}
+            onClick={() => setActiveTab('posts')}
+          >
+            내가 쓴 글
+          </li>
+          <li
+            className={`${activeTab === 'likes' ? 'text-black ' : 'text-gray-500'}`}
+            onClick={() => setActiveTab('likes')}
+          >
+            좋아요 한 글
+          </li>
+          <li
+            className={`${activeTab === 'bookmarks' ? 'text-black ' : 'text-gray-500'}`}
+            onClick={() => setActiveTab('bookmarks')}
+          >
+            북마크
+          </li>
+        </ul>
+      </nav>
+    </header>
+  );
+};
+
+export default MyActivitiesHeader;

--- a/src/app/(home)/(profile)/_components/myactivities/MyActivitiesHeader.tsx
+++ b/src/app/(home)/(profile)/_components/myactivities/MyActivitiesHeader.tsx
@@ -5,7 +5,7 @@ type MyActivitiesHeaderProps = {
   activeTab: string;
 };
 
-const MyActivitiesHeader: React.FC<MyActivitiesHeaderProps> = ({ setActiveTab, activeTab }) => {
+const MyActivitiesHeader = ({ setActiveTab, activeTab }: MyActivitiesHeaderProps) => {
   return (
     <header>
       <nav className="w-full bg-[#E3E3E3] p-5 overflow-y-hidden">

--- a/src/app/(home)/(profile)/_components/myactivities/MyPostsList.tsx
+++ b/src/app/(home)/(profile)/_components/myactivities/MyPostsList.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import PostCard from './PostCard';
+import CommentCard from './CommentCard';
+
+//임시
+type PostType = {
+  id: string;
+  type: 'post';
+  title: string;
+  content: string;
+  tags: string[];
+  time: Date;
+};
+
+type CommentType = {
+  id: string;
+  type: 'comment';
+  postId: string;
+  content: string;
+  profilePicture: string;
+  image: string;
+  time: Date;
+};
+
+type PostOrComment = PostType | CommentType;
+
+const MyPostsList = (filter: any) => {
+  // 예시 데이터
+  const postsAndComments: PostOrComment[] = [
+    // 게시글과 댓글 데이터가 여기에 들어갑니다.
+  ];
+  const sortedPostsAndComments = postsAndComments.sort((a, b) => b.time.getTime() - a.time.getTime());
+  return (
+    <div>
+      {sortedPostsAndComments.map((item) => {
+        if (item.type === 'post') {
+          return <PostCard key={item.id} title={item.title} content={item.content} tags={item.tags} time={item.time} />;
+        } else if (item.type === 'comment') {
+          return (
+            <CommentCard
+              key={item.id}
+              content={item.content}
+              profilePicture={item.profilePicture}
+              image={item.image}
+              time={item.time}
+            />
+          );
+        }
+        return null;
+      })}
+    </div>
+  );
+};
+
+export default MyPostsList;

--- a/src/app/(home)/(profile)/_components/myactivities/MyPostsList.tsx
+++ b/src/app/(home)/(profile)/_components/myactivities/MyPostsList.tsx
@@ -8,6 +8,7 @@ type PostType = {
   type: 'post';
   title: string;
   content: string;
+  image: string;
   tags: string[];
   time: Date;
 };
@@ -15,10 +16,11 @@ type PostType = {
 type CommentType = {
   id: string;
   type: 'comment';
+  title: string;
   postId: string;
-  content: string;
-  profilePicture: string;
-  image: string;
+  comment: string;
+  userNickname: string;
+  userImage: string;
   time: Date;
 };
 
@@ -34,14 +36,24 @@ const MyPostsList = (filter: any) => {
     <div>
       {sortedPostsAndComments.map((item) => {
         if (item.type === 'post') {
-          return <PostCard key={item.id} title={item.title} content={item.content} tags={item.tags} time={item.time} />;
+          return (
+            <PostCard
+              key={item.id}
+              title={item.title}
+              content={item.content}
+              image={item.image}
+              tags={item.tags}
+              time={item.time}
+            />
+          );
         } else if (item.type === 'comment') {
           return (
             <CommentCard
               key={item.id}
-              content={item.content}
-              profilePicture={item.profilePicture}
-              image={item.image}
+              title={item.title}
+              comment={item.comment}
+              userNickname={item.userNickname}
+              userImage={item.userImage}
               time={item.time}
             />
           );

--- a/src/app/(home)/(profile)/_components/myactivities/PostCard.tsx
+++ b/src/app/(home)/(profile)/_components/myactivities/PostCard.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface PostCardProps {
+  title: string;
+  content: string;
+  tags: string[];
+  time: Date;
+}
+
+const PostCard: React.FC<PostCardProps> = ({ title, content, tags, time }) => {
+  return (
+    <div>
+      <p>{title}</p>
+      <p>{content}</p>
+      <p>{tags.join(', ')}</p>
+      <p>{time.toLocaleString()}</p>
+    </div>
+  );
+};
+
+export default PostCard;

--- a/src/app/(home)/(profile)/_components/myactivities/PostCard.tsx
+++ b/src/app/(home)/(profile)/_components/myactivities/PostCard.tsx
@@ -1,17 +1,21 @@
 import React from 'react';
 
-interface PostCardProps {
+type PostCardProps = {
   title: string;
   content: string;
+  image: string;
   tags: string[];
   time: Date;
-}
+};
 
-const PostCard: React.FC<PostCardProps> = ({ title, content, tags, time }) => {
+const PostCard = ({ title, content, image, tags, time }: PostCardProps) => {
   return (
     <div>
       <p>{title}</p>
-      <p>{content}</p>
+      <p>
+        {content}
+        <img src={image} alt="post Image" />
+      </p>
       <p>{tags.join(', ')}</p>
       <p>{time.toLocaleString()}</p>
     </div>

--- a/src/app/(home)/(profile)/_components/setting/EditableField.tsx
+++ b/src/app/(home)/(profile)/_components/setting/EditableField.tsx
@@ -9,7 +9,7 @@ type EditableFieldProps = {
   onLabelClick: (field: string) => void;
 };
 
-const EditableField: React.FC<EditableFieldProps> = ({ label, name, value, showInput, onChange, onLabelClick }) => {
+const EditableField = ({ label, name, value, showInput, onChange, onLabelClick }: EditableFieldProps) => {
   return (
     <div className="flex items-center mb-4">
       <div className="w-1/3 min-w-[120px]">

--- a/src/app/(home)/(profile)/_components/setting/EditableField.tsx
+++ b/src/app/(home)/(profile)/_components/setting/EditableField.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+type EditableFieldProps = {
+  label: string;
+  name: string;
+  value: string;
+  showInput: string | null;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onLabelClick: (field: string) => void;
+};
+
+const EditableField: React.FC<EditableFieldProps> = ({ label, name, value, showInput, onChange, onLabelClick }) => {
+  return (
+    <div className="flex items-center mb-4">
+      <div className="w-1/3 min-w-[120px]">
+        <label className="font-medium">{label}</label>
+      </div>
+      <div className="w-2/3">
+        {showInput === name ? (
+          <input
+            type="text"
+            name={name}
+            value={value}
+            onChange={onChange}
+            className="w-full border border-gray-300 p-2 rounded"
+          />
+        ) : (
+          <label onClick={() => onLabelClick(name)} className="cursor-pointer">
+            {value} ›
+          </label>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default EditableField;

--- a/src/app/(home)/(profile)/layout.tsx
+++ b/src/app/(home)/(profile)/layout.tsx
@@ -5,7 +5,7 @@ type ProfileLayoutProps = {
   children: React.ReactNode;
 };
 
-const ProfileLayout: React.FC<ProfileLayoutProps> = ({ children }) => {
+const ProfileLayout = ({ children }: ProfileLayoutProps) => {
   return (
     <div className="flex justify-center w-[1200px] h-screen">
       <ProfileSidebar />

--- a/src/app/(home)/(profile)/layout.tsx
+++ b/src/app/(home)/(profile)/layout.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ProfileSidebar from './_components/ProfileSidebar';
+
+type ProfileLayoutProps = {
+  children: React.ReactNode;
+};
+
+const ProfileLayout: React.FC<ProfileLayoutProps> = ({ children }) => {
+  return (
+    <div className="flex justify-center w-[1200px] h-screen">
+      <ProfileSidebar />
+      <main className="flex-1 p-10">{children}</main>
+    </div>
+  );
+};
+
+export default ProfileLayout;

--- a/src/app/(home)/(profile)/profile/activities/page.tsx
+++ b/src/app/(home)/(profile)/profile/activities/page.tsx
@@ -1,0 +1,11 @@
+import MyActivities from '../../_components/MyActivities';
+
+const ProfileActivitiesPage = () => {
+  return (
+    <div>
+      <MyActivities />
+    </div>
+  );
+};
+
+export default ProfileActivitiesPage;

--- a/src/app/(home)/(profile)/profile/edit/page.tsx
+++ b/src/app/(home)/(profile)/profile/edit/page.tsx
@@ -1,5 +1,0 @@
-const ProfileEditPage = () => {
-  return <div></div>;
-};
-
-export default ProfileEditPage;

--- a/src/app/(home)/(profile)/profile/page.tsx
+++ b/src/app/(home)/(profile)/profile/page.tsx
@@ -1,5 +1,11 @@
+import ProfileContent from '../_components/ProfileContent';
+
 const ProfilePage = () => {
-  return <div></div>;
+  return (
+    <div>
+      <ProfileContent />
+    </div>
+  );
 };
 
 export default ProfilePage;

--- a/src/app/(home)/(profile)/profile/settings/page.tsx
+++ b/src/app/(home)/(profile)/profile/settings/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ProfileSetting from '../../_components/ProfileSetting';
+
+const ProfileSettingsPage = () => {
+  return (
+    <div>
+      <ProfileSetting />
+    </div>
+  );
+};
+
+export default ProfileSettingsPage;

--- a/src/store/useActiveTabStore.ts
+++ b/src/store/useActiveTabStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+type ActiveTabState = {
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+};
+
+const useActiveTabStore = create<ActiveTabState>((set) => ({
+  activeTab: 'posts',
+  setActiveTab: (tab) => set({ activeTab: tab })
+}));
+
+export default useActiveTabStore;


### PR DESCRIPTION
## 연결된 이슈번호

### closes #23 
### closes #24 
### closes #25 

## Description

### 사이드 바 작업 및 프로필 ui

>

## To-Do

-   [ ] 사이드바 (프로필 (기본선택), 내 활동, 설정, 로그아웃)
-   [ ] 프로필 일때 > 프로필 사진 닉네임 /깃허브 링크 (연동 됨 / 연동 안됨) / 링크 가는 버튼
-   [ ]자기소개
-   [ ]북마크 갯수 좋아요 갯수 > 북마크 좋아요 누르면 내 활동 탭에서 북마크나 좋아요로 이동함
-   [ ] 최상단에 내가 쓴 글, 좋아요 한 글, 북마크 한 글을 이동할수 있는 네비게이션 바가 있습니다. 주의해 주세요.
-   [ ]내가 쓴 글에서는 게시글밖에 안보입니다 게시글 ui를 공용 컴포넌트로 만들어 주세요
-   [ ] 좋아요 한 글과 북마크 한 글은 댓글도 표시됩니다 댓글 표시 ui를 공용 컴포넌트로 만들어 주세요
-   [ ]계정 관리 페이지라는걸 인식시켜줄 설명 div를 만들어주세요
-   [ ] 유저 프로필 이미지를 바꿀수 있습니다.
-   [ ] 유저 넥네임도 바꿀수 있습니다
-   [ ] 깃허브 링크도 바꿀수 있습니다
-   [ ] 자기소개 내용도 바꿀수 있습니다.
-   [ ] (추가기능) 회원 탈퇴 버튼을 만들어 주세요
## ETC

### 기타 알려야 하는 상황을 적어주세요

>
