### PR TITLE
update: reusable button ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tanstack/react-query-devtools": "^5.51.9",
         "@uiw/react-md-editor": "^4.0.4",
         "axios": "^1.7.2",
+        "class-variance-authority": "^0.7.0",
         "dayjs": "^1.11.12",
         "next": "14.2.5",
         "prettier": "^3.3.3",
@@ -1564,6 +1565,25 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
+      "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
+      "dependencies": {
+        "clsx": "2.0.0"
+      },
+      "funding": {
+        "url": "https://joebell.co.uk"
+      }
+    },
+    "node_modules/class-variance-authority/node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/client-only": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-query-devtools": "^5.51.9",
     "@uiw/react-md-editor": "^4.0.4",
     "axios": "^1.7.2",
+    "class-variance-authority": "^0.7.0",
     "dayjs": "^1.11.12",
     "next": "14.2.5",
     "prettier": "^3.3.3",

--- a/src/components/common/Chip.tsx
+++ b/src/components/common/Chip.tsx
@@ -1,0 +1,64 @@
+import { cva } from 'class-variance-authority';
+import '@/app/globals.css';
+import { ComponentProps } from 'react';
+
+const largeChipVarients = cva(['text-subtitle1', 'font-bold', 'content-center', 'text-center'], {
+  variants: {
+    intent: {
+      primary: ['bg-main-400', 'text-white', 'hover:bg-main-500', 'active:bg-main-500'],
+      primary_disabled: ['bg-main-100', 'text-neutral-50'],
+      secondary: ['bg-main-50', 'text-main-400', 'hover:bg-main-100', 'active:bg-main-100'],
+      secondary_disabled: ['bg-main-50', 'text-main-100'],
+      gray: ['bg-neutral-50', 'text-neutral-500', 'hover:bg-neutral-100', 'active:text-neutral-500'],
+      gray_disabled: ['bg-neutral-50', 'text-neutral-100'],
+      default: [
+        'bg-white',
+        'border border-neutral-200',
+        'text-neutral-500',
+        'hover:bg-neutral-50',
+        'active:bg-neutral-50'
+      ],
+      default_disabled: ['bg-white', 'border border-neutral-200', 'text-neutral-100']
+    },
+    size: {
+      large: 'px-6 py-4 w-[130px] h-14 rounded-lg',
+      medium: 'px-5 py-3 w-[122px] h-12 rounded-md',
+      small: 'px-4 py-2 w-[114px] h-10 rounded'
+    }
+  },
+
+  compoundVariants: [
+    {
+      intent: 'primary',
+      size: 'medium'
+    }
+  ],
+  defaultVariants: {
+    intent: 'primary',
+    size: 'medium'
+  }
+});
+
+type ChipProps = ComponentProps<'button'> & {
+  label: string;
+  intent?:
+    | 'primary'
+    | 'primary_disabled'
+    | 'secondary'
+    | 'secondary_disabled'
+    | 'gray'
+    | 'gray_disabled'
+    | 'default'
+    | 'default_disabled';
+  size?: 'large' | 'medium' | 'small';
+};
+
+function Chip({ label, intent, size, ...props }: ChipProps) {
+  return (
+    <button className={largeChipVarients({ intent, size })} {...props}>
+      {label}
+    </button>
+  );
+}
+
+export default Chip;


### PR DESCRIPTION
## 연결된 이슈번호

### closes #210 

## Description

### 무슨 작업을 했는지 알려주세요

> 재사용 가능한 버튼 컴포넌트 제작

## To-Do

-   [ ] 재사용 가능한 버튼 컴포넌트 제작

## ETC

### 기타 알려야 하는 상황을 적어주세요

> 사용법입니다!

![image](https://github.com/user-attachments/assets/8afe4c5c-9b00-4c79-a555-234045b9017c)

피그마에서 버튼을 누르면 Priority와 Size정보가 나옵니다
intent에 Priority를, size에 Size를 넣으시면 원하는 버튼이 나옵니다

기본 버튼 예시
<Chip intent={"primary"} size={"medium"} label={텍스트}>

![image](https://github.com/user-attachments/assets/bf2698d6-a795-4d60-92f7-882cfb46f9a2)
비활성 버튼은 Design System에 보니 hover나 active효과가 없는 것 같아서 넣지 않았습니다.
비활성 버튼은 state에 disabled 라고 적혀 있습니다.

비활성 버튼 사용 예시
<Chip intent={"primary_disabled"} size={"medium"} label={텍스트}>

intent에 넣을 값에 _disabled를 붙여주시면 됩니다.
wiki에도 남겨두겠습니다.